### PR TITLE
CI: deploy to GitHub Pages

### DIFF
--- a/.cursor/rules/launched-effect-state.mdc
+++ b/.cursor/rules/launched-effect-state.mdc
@@ -1,0 +1,48 @@
+---
+description: Не использовать LaunchedEffect с ключом-стейтом в Compose
+globs: **/*.kt
+alwaysApply: true
+---
+
+# LaunchedEffect и стейт
+
+Не используй `LaunchedEffect` с ключом в виде стейта (`State`, `collectAsState()`, параметры composable).
+
+Стейт уже триггерит рекомпозицию — логику выполняй прямо в теле composable.
+
+## ❌ Плохо
+
+```kotlin
+LaunchedEffect(authState) {
+    if (authState == AuthState.Authenticated) {
+        ctx.router.tryRoutingTo("/profile")
+    }
+}
+
+LaunchedEffect(colorMode) {
+    localStorage.setItem(COLOR_MODE_KEY, colorMode.name)
+}
+
+LaunchedEffect(title) {
+    document.title = "Kobweb - $title"
+}
+```
+
+## ✅ Хорошо
+
+```kotlin
+if (authState == AuthState.Authenticated) {
+    ctx.router.tryRoutingTo("/profile")
+}
+
+SideEffect {
+    localStorage.setItem(COLOR_MODE_KEY, colorMode.name)
+}
+
+document.title = "Kobweb - $title"
+```
+
+## Исключения
+
+`LaunchedEffect` допустим для разовых эффектов без ключа-стейта (например, загрузка при появлении composable) или с ключом-идентификатором, не связанным с отображаемым стейтом.
+

--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -1,0 +1,35 @@
+# Настройка репозитория
+
+## 1. GitHub Pages
+
+1. **Settings** → **Pages**
+2. В **Build and deployment** → **Source** выбрать **GitHub Actions**
+3. После мержа в `master` вкладка **Actions** покажет workflow, а сайт будет доступен по:
+   ```
+   https://<owner>.github.io/<repo>/
+   ```
+
+## 2. Защита ветки master
+
+1. **Settings** → **Branches** → **Add rule**
+2. **Branch name pattern**: `master`
+3. Включить:
+   - **Require a pull request before merging** (обязательный PR)
+   - **Require approvals** — при необходимости указать число одобрений (например, 1)
+   - **Require status checks to pass before merging** — выбрать чек из workflow **Deploy to GitHub Pages**
+4. **Create**
+
+### Через GitHub CLI (опционально)
+
+```bash
+gh api repos/OWNER/REPO/branches/master/protection \
+  -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  -f required_status_checks='null' \
+  -f enforce_admins=false \
+  -F required_pull_request_reviews='{"required_approving_review_count":1}' \
+  -f restrictions='null'
+```
+
+Подставьте `OWNER` и `REPO` вместо placeholder'ов.
+

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,83 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    env:
+      KOBWEB_CLI_VERSION: "0.9.21"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # When projects are created on Windows, the executable bit is sometimes lost. So set it back just in case.
+      - name: Ensure Gradle is executable
+        run: chmod +x gradlew
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Query Browser Cache ID
+        id: browser-cache-id
+        run: echo "value=$(./gradlew -q :site:kobwebBrowserCacheId)" >> $GITHUB_OUTPUT
+
+      - name: Cache Browser Dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.browser-cache-id.outputs.value }}
+
+      - name: Fetch Kobweb CLI
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: "varabyte/kobweb-cli"
+          tag: "v${{ env.KOBWEB_CLI_VERSION }}"
+          fileName: "kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip"
+          tarBall: false
+          zipBall: false
+
+      - name: Unzip Kobweb CLI
+        run: unzip -o kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip
+
+      - name: Run export
+        run: |
+          cd site
+          ../kobweb-${{ env.KOBWEB_CLI_VERSION }}/bin/kobweb export --notty --layout static
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site/.kobweb/site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: export
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
Add GitHub Actions workflow to export Kobweb site and deploy to GitHub Pages on every push to master (including PR merges). Also include Cursor rules.