### PR TITLE
CI: pin Kobweb CLI to 0.9.15 for Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
   export:
     runs-on: ubuntu-latest
     env:
-      KOBWEB_CLI_VERSION: "0.9.21"
+      KOBWEB_CLI_VERSION: "0.9.15"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- pin GitHub Pages workflow `KOBWEB_CLI_VERSION` to `0.9.15`
- fix export failure caused by CLI `0.9.21` passing unsupported `FULLSTACK` layout to this project
- keep deploy pipeline behavior unchanged otherwise

## Test plan
- [x] Reproduce CI command locally with `kobweb-cli 0.9.21` and confirm failure (`No enum constant ... SiteLayout.FULLSTACK`)
- [x] Re-run local export with `kobweb-cli 0.9.15` and confirm successful static export
- [ ] Run GitHub Actions workflow `Deploy to GitHub Pages` on this branch