### PR TITLE
fix(ci): stabilize GitHub Pages export paths

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,8 +18,6 @@ concurrency:
 jobs:
   export:
     runs-on: ubuntu-latest
-    env:
-      KOBWEB_CLI_VERSION: "0.9.15"
 
     steps:
       - name: Checkout
@@ -48,22 +46,30 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.browser-cache-id.outputs.value }}
 
-      - name: Fetch Kobweb CLI
-        uses: robinraju/release-downloader@v1.10
-        with:
-          repository: "varabyte/kobweb-cli"
-          tag: "v${{ env.KOBWEB_CLI_VERSION }}"
-          fileName: "kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip"
-          tarBall: false
-          zipBall: false
-
-      - name: Unzip Kobweb CLI
-        run: unzip -o kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip
-
       - name: Run export
+        run: ./gradlew :site:kobwebExport -Dkobweb.site.layout=STATIC
+
+      - name: Patch HTML asset paths for project pages
         run: |
-          cd site
-          ../kobweb-${{ env.KOBWEB_CLI_VERSION }}/bin/kobweb export --notty --layout static
+          python - <<'PY'
+          from pathlib import Path
+
+          base_path = "/lk-web"
+          site_root = Path("site/.kobweb/site")
+          replacements = {
+              'href="/favicon.ico"': f'href="{base_path}/resources/favicon.ico"',
+              'src="/kobweb-logo.png"': f'src="{base_path}/resources/kobweb-logo.png"',
+              'src="/testKotlin.js"': f'src="{base_path}/system/testKotlin.js"',
+          }
+
+          for html_file in site_root.rglob("*.html"):
+              content = html_file.read_text(encoding="utf-8")
+              updated = content
+              for old, new in replacements.items():
+                  updated = updated.replace(old, new)
+              if updated != content:
+                  html_file.write_text(updated, encoding="utf-8")
+          PY
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- switch Pages export to Gradle (`:site:kobwebExport`) to avoid external Kobweb CLI version drift
- patch exported HTML links to use `/lk-web` project paths for `testKotlin.js` and static assets
- keep artifact upload unchanged (`site/.kobweb/site`) so deploy flow remains the same

## Test plan
- [x] run `./gradlew :site:kobwebExport -Dkobweb.site.layout=STATIC`
- [x] verify exported HTML references `/lk-web/system/testKotlin.js`
- [ ] run GitHub Actions `Deploy to GitHub Pages`
- [ ] open `https://clear-docs.github.io/lk-web/` and confirm no 404 for `testKotlin.js`
