### PR TITLE
fix(ci): restore Java 17 + Kobweb CLI 0.9.15 to fix empty export

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         shell: bash
     env:
-      KOBWEB_CLI_VERSION: "0.9.21"
+      KOBWEB_CLI_VERSION: "0.9.15"
 
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "11"
+          java-version: "17"
 
       # When projects are created on Windows, the executable bit is sometimes lost. So set it back just in case.
       - name: Ensure Gradle is executable
@@ -75,8 +75,9 @@ jobs:
 
       - name: Validate export artifact directory
         run: |
-          test -d site/.kobweb/site || {
-            echo "Expected export directory site/.kobweb/site is missing"
+          test -f site/.kobweb/site/index.html || test -f site/.kobweb/site/pages/index.html || {
+            echo "ERROR: Export produced no index.html -- build is broken"
+            ls -laR site/.kobweb/site/ 2>/dev/null || true
             exit 1
           }
 


### PR DESCRIPTION
Restore Java 17 and Kobweb CLI 0.9.15 so `kobweb export` builds correctly (Java 11 + CLI 0.9.21 produced empty 285-byte artifact → 404 on lk.cleardocs.ru). Harden validation to require index.html in export artifact.