### PR TITLE
api.cleardocs.ru: production API URL + signOutAwait

### DIFF
--- a/site/src/jsMain/kotlin/ru/cleardocs/lkweb/ApiConfig.kt
+++ b/site/src/jsMain/kotlin/ru/cleardocs/lkweb/ApiConfig.kt
@@ -13,13 +13,13 @@ import io.ktor.serialization.kotlinx.json.json
  * Настройки Ktor: базовый URL сервера API.
  */
 object ApiConfig {
-    /** Базовый URL ClearDocs API. На localhost — CORS-прокси 9082 -> 155.212.162.11:8080, иначе бэкенд напрямую. */
+    /** Базовый URL ClearDocs API. На localhost — CORS-прокси 9082, иначе api.cleardocs.ru (nginx → backend:8080). */
     val baseUrl: String
         get() {
             val h = window.location.hostname
             return when {
                 h == "localhost" || h == "127.0.0.1" -> "http://localhost:9082"
-                else -> "http://155.212.162.11:8080"
+                else -> "https://api.cleardocs.ru"
             }
         }
 

--- a/site/src/jsMain/kotlin/ru/cleardocs/lkweb/firebase/Firebase.kt
+++ b/site/src/jsMain/kotlin/ru/cleardocs/lkweb/firebase/Firebase.kt
@@ -181,6 +181,18 @@ fun signOut(auth: dynamic) {
     }
 }
 
+/** Suspend-версия signOut — ждёт завершения Promise. Используется при редиректе по 401, чтобы избежать цикла auth↔profile. */
+suspend fun signOutAwait(auth: dynamic) {
+    try {
+        val promise = FirebaseAuth.signOut(auth)
+        if (promise != null && jsTypeOf(promise.asDynamic().then) == "function") {
+            promiseToSuspend<Unit>(promise)
+        }
+    } catch (e: dynamic) {
+        console.error("Firebase: signOutAwait error", e)
+    }
+}
+
 suspend fun signInWithEmailAndPassword(auth: dynamic, email: String, password: String): dynamic {
     return promiseToSuspend<dynamic>(FirebaseAuth.signInWithEmailAndPassword(auth, email, password))
 }


### PR DESCRIPTION
- ApiConfig: use https://api.cleardocs.ru instead of http://155.212.162.11:8080
- Firebase: add signOutAwait() for redirect loop fix (401→auth)