### PR TITLE
fix: экспорт через Gradle вместо kobweb CLI для CI

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,9 +21,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      KOBWEB_CLI_VERSION: "0.9.15"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,22 +48,8 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.browser-cache-id.outputs.value }}
 
-      - name: Fetch Kobweb CLI
-        uses: robinraju/release-downloader@v1.10
-        with:
-          repository: "varabyte/kobweb-cli"
-          tag: "v${{ env.KOBWEB_CLI_VERSION }}"
-          fileName: "kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip"
-          tarBall: false
-          zipBall: false
-
-      - name: Unzip Kobweb CLI
-        run: unzip -o kobweb-${{ env.KOBWEB_CLI_VERSION }}.zip
-
       - name: Run export
-        run: |
-          cd site
-          ../kobweb-${{ env.KOBWEB_CLI_VERSION }}/bin/kobweb export --notty --layout static
+        run: ./gradlew :site:kobwebExport --no-daemon -PkobwebExportLayout=STATIC
 
       - name: Add CNAME for custom domain
         run: |


### PR DESCRIPTION
Kobweb CLI не создавал index.html в CI. Заменено на ./gradlew :site:kobwebExport, который работает локально.